### PR TITLE
Tw/interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ repo = "https://github.com/JuliaAlgebra/MultivariateBases.jl.git"
 version = "0.2.1"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 

--- a/src/MultivariateBases.jl
+++ b/src/MultivariateBases.jl
@@ -29,6 +29,8 @@ export generators,
     reccurence_third_coef,
     reccurence_deno_coef
 include("fixed.jl")
+
+import LinearAlgebra
 include("orthogonal.jl")
 include("hermite.jl")
 include("laguerre.jl")

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -28,7 +28,7 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(variable + 0)
 end
 
-function scalar_product_function(::Type{<:ChebyshevBasisFirstKind}, i::Int)
+function _scalar_product_function(::Type{<:ChebyshevBasisFirstKind}, i::Int)
     if i == 0
         return π
     elseif isodd(i)
@@ -57,7 +57,7 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(2variable + 0)
 end
 
-function scalar_product_function(::Type{<:ChebyshevBasisSecondKind}, i::Int)
+function _scalar_product_function(::Type{<:ChebyshevBasisSecondKind}, i::Int)
     if i == 0
         return π / 2
     elseif isodd(i)

--- a/src/chebyshev.jl
+++ b/src/chebyshev.jl
@@ -28,6 +28,17 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(variable + 0)
 end
 
+function scalar_product_function(::Type{<:ChebyshevBasisFirstKind}, i::Int)
+    if i == 0
+        return π
+    elseif isodd(i)
+        return 0
+    else
+        n = div(i, 2)
+        return (π / 2^i) * prod(n+1:i) / factorial(n)
+    end
+end
+
 """
     struct ChebyshevBasisSecondKind{P} <: AbstractChebyshevBasis{P}
         polynomials::Vector{P}
@@ -44,4 +55,15 @@ function degree_one_univariate_polynomial(
     variable::MP.AbstractVariable,
 )
     MA.@rewrite(2variable + 0)
+end
+
+function scalar_product_function(::Type{<:ChebyshevBasisSecondKind}, i::Int)
+    if i == 0
+        return π / 2
+    elseif isodd(i)
+        return 0
+    else
+        n = div(i, 2)
+        return π / (2^(i + 1)) * prod(n+2:i) / factorial(n)
+    end
 end

--- a/src/hermite.jl
+++ b/src/hermite.jl
@@ -30,6 +30,17 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(1variable)
 end
 
+function scalar_product_function(::Type{<:ProbabilistsHermiteBasis}, i::Int)
+    if i == 0
+        return √(2 * π)
+    elseif isodd(i)
+        return 0
+    else
+        n = div(i, 2)
+        return (√(2 * π) / (2^n)) * prod(n+1:2*n)
+    end
+end
+
 """
     struct PhysicistsHermiteBasis{P} <: AbstractHermiteBasis{P}
         polynomials::Vector{P}
@@ -47,4 +58,15 @@ function degree_one_univariate_polynomial(
     variable::MP.AbstractVariable,
 )
     MA.@rewrite(2variable)
+end
+
+function scalar_product_function(::Type{<:PhysicistsHermiteBasis}, i::Int)
+    if i == 0
+        return √(π)
+    elseif isodd(i)
+        return 0
+    else
+        n = div(i, 2)
+        return (√(π) / (2^i)) * prod(n+1:i)
+    end
 end

--- a/src/hermite.jl
+++ b/src/hermite.jl
@@ -30,7 +30,7 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(1variable)
 end
 
-function scalar_product_function(::Type{<:ProbabilistsHermiteBasis}, i::Int)
+function _scalar_product_function(::Type{<:ProbabilistsHermiteBasis}, i::Int)
     if i == 0
         return √(2 * π)
     elseif isodd(i)
@@ -60,7 +60,7 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(2variable)
 end
 
-function scalar_product_function(::Type{<:PhysicistsHermiteBasis}, i::Int)
+function _scalar_product_function(::Type{<:PhysicistsHermiteBasis}, i::Int)
     if i == 0
         return √(π)
     elseif isodd(i)

--- a/src/laguerre.jl
+++ b/src/laguerre.jl
@@ -26,3 +26,7 @@ function degree_one_univariate_polynomial(
 )
     MA.@rewrite(1 - variable)
 end
+
+function scalar_product_function(::Type{<:LaguerreBasis}, i::Int)
+    return factorial(i)
+end

--- a/src/laguerre.jl
+++ b/src/laguerre.jl
@@ -27,6 +27,6 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(1 - variable)
 end
 
-function scalar_product_function(::Type{<:LaguerreBasis}, i::Int)
+function _scalar_product_function(::Type{<:LaguerreBasis}, i::Int)
     return factorial(i)
 end

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -36,7 +36,7 @@ function degree_one_univariate_polynomial(
     MA.@rewrite(variable + 0)
 end
 
-function scalar_product_function(::Type{<:LegendreBasis}, i::Int)
+function _scalar_product_function(::Type{<:LegendreBasis}, i::Int)
     if isodd(i)
         return 0
     else

--- a/src/legendre.jl
+++ b/src/legendre.jl
@@ -35,3 +35,11 @@ function degree_one_univariate_polynomial(
 )
     MA.@rewrite(variable + 0)
 end
+
+function scalar_product_function(::Type{<:LegendreBasis}, i::Int)
+    if isodd(i)
+        return 0
+    else
+        return 2 / (i + 1)
+    end
+end

--- a/src/monomial.jl
+++ b/src/monomial.jl
@@ -91,6 +91,10 @@ function MP.polynomial(Q::AbstractMatrix, mb::MonomialBasis, T::Type)
     return MP.polynomial(Q, mb.monomials, T)
 end
 
+function MP.coefficients(p, basis::MonomialBasis)
+    return MP.coefficients(p, basis.monomials)
+end
+
 function MP.coefficients(p, ::Type{<:MonomialBasis})
     return MP.coefficients(p)
 end

--- a/src/orthogonal.jl
+++ b/src/orthogonal.jl
@@ -159,7 +159,7 @@ function basis_covering_monomials(
     )
 end
 
-function scalar_product_function(
+function _scalar_product_function(
     ::Type{<:AbstractMultipleOrthogonalBasis},
     i::Int,
 ) end
@@ -176,14 +176,14 @@ function _integral(
     p::Number,
     basis_type::Type{<:AbstractMultipleOrthogonalBasis},
 )
-    return p * scalar_product_function(basis_type, 0)
+    return p * _scalar_product_function(basis_type, 0)
 end
 
 function _integral(
     p::MP.AbstractVariable,
     basis_type::Type{<:AbstractMultipleOrthogonalBasis},
 )
-    return scalar_product_function(basis_type, 1)
+    return _scalar_product_function(basis_type, 1)
 end
 
 function _integral(
@@ -191,7 +191,7 @@ function _integral(
     basis_type::Type{<:AbstractMultipleOrthogonalBasis},
 )
     return prod([
-        scalar_product_function(basis_type, i) for i in MP.exponents(p)
+        _scalar_product_function(basis_type, i) for i in MP.exponents(p)
     ])
 end
 

--- a/src/orthogonal.jl
+++ b/src/orthogonal.jl
@@ -158,3 +158,44 @@ function basis_covering_monomials(
         MP.monomial_vector(collect(m)),
     )
 end
+
+function scalar_product_function(::Type{<:AbstractMultipleOrthogonalBasis}, i::Int) end
+
+LinearAlgebra.dot(p, q, basis_type::Type{<:AbstractMultipleOrthogonalBasis}) =
+    _integral(p * q, basis_type)
+
+function _integral(p::Number, basis_type::Type{<:AbstractMultipleOrthogonalBasis})
+    return p * scalar_product_function(basis_type, 0)
+end
+
+function _integral(
+    p::MP.AbstractVariable,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
+    return scalar_product_function(basis_type, 1)
+end
+
+function _integral(
+    p::MP.AbstractMonomial,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
+    return prod([scalar_product_function(basis_type, i) for i in MP.exponents(p)])
+end
+
+function _integral(p::MP.AbstractTerm, basis_type::Type{<:AbstractMultipleOrthogonalBasis})
+    return MP.coefficient(p) * _integral(MP.monomial(p), basis_type)
+end
+
+function _integral(
+    p::MP.AbstractPolynomial,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
+    return sum([_integral(t, basis_type) for t in MP.terms(p)])
+end
+
+function MP.coefficients(p, basis::AbstractMultipleOrthogonalBasis; check = true)
+    B = typeof(basis)
+    coeffs = [LinearAlgebra.dot(p, el, B) / LinearAlgebra.dot(el, el, B) for el in basis]
+    idx = findall(c -> !isapprox(c, 0, atol = 1e-10), coeffs)
+    return coeffs[idx]
+end

--- a/src/orthogonal.jl
+++ b/src/orthogonal.jl
@@ -159,12 +159,23 @@ function basis_covering_monomials(
     )
 end
 
-function scalar_product_function(::Type{<:AbstractMultipleOrthogonalBasis}, i::Int) end
+function scalar_product_function(
+    ::Type{<:AbstractMultipleOrthogonalBasis},
+    i::Int,
+) end
 
-LinearAlgebra.dot(p, q, basis_type::Type{<:AbstractMultipleOrthogonalBasis}) =
-    _integral(p * q, basis_type)
+function LinearAlgebra.dot(
+    p,
+    q,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
+    return _integral(p * q, basis_type)
+end
 
-function _integral(p::Number, basis_type::Type{<:AbstractMultipleOrthogonalBasis})
+function _integral(
+    p::Number,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
     return p * scalar_product_function(basis_type, 0)
 end
 
@@ -179,10 +190,15 @@ function _integral(
     p::MP.AbstractMonomial,
     basis_type::Type{<:AbstractMultipleOrthogonalBasis},
 )
-    return prod([scalar_product_function(basis_type, i) for i in MP.exponents(p)])
+    return prod([
+        scalar_product_function(basis_type, i) for i in MP.exponents(p)
+    ])
 end
 
-function _integral(p::MP.AbstractTerm, basis_type::Type{<:AbstractMultipleOrthogonalBasis})
+function _integral(
+    p::MP.AbstractTerm,
+    basis_type::Type{<:AbstractMultipleOrthogonalBasis},
+)
     return MP.coefficient(p) * _integral(MP.monomial(p), basis_type)
 end
 
@@ -193,9 +209,16 @@ function _integral(
     return sum([_integral(t, basis_type) for t in MP.terms(p)])
 end
 
-function MP.coefficients(p, basis::AbstractMultipleOrthogonalBasis; check = true)
+function MP.coefficients(
+    p,
+    basis::AbstractMultipleOrthogonalBasis;
+    check = true,
+)
     B = typeof(basis)
-    coeffs = [LinearAlgebra.dot(p, el, B) / LinearAlgebra.dot(el, el, B) for el in basis]
-    idx = findall(c -> !isapprox(c, 0, atol = 1e-10), coeffs)
+    coeffs = [
+        LinearAlgebra.dot(p, el, B) / LinearAlgebra.dot(el, el, B) for
+        el in basis
+    ]
+    idx = findall(c -> !isapprox(c, 0; atol = 1e-10), coeffs)
     return coeffs[idx]
 end

--- a/src/scaled.jl
+++ b/src/scaled.jl
@@ -76,7 +76,7 @@ function change_basis(
 ) where {MT,MV}
     n = length(basis)
     scalings = map(scaling, basis.monomials)
-    scaled_Q = [Q[i, j] * scalings[i] * scalings[j] for i in 1:n, j in 1:n]
+    scaled_Q = [Q[i, j] * scalings[i] * scalings[j] for i = 1:n, j = 1:n]
     return scaled_Q, MonomialBasis(basis.monomials)
 end
 
@@ -94,4 +94,7 @@ end
 unscale_coef(t::MP.AbstractTerm) = MP.coefficient(t) / scaling(MP.monomial(t))
 function MP.coefficients(p, ::Type{<:ScaledMonomialBasis})
     return unscale_coef.(MP.terms(p))
+end
+function MP.coefficients(p, basis::ScaledMonomialBasis)
+    return MP.coefficients(p, basis.monomials) ./ scaling.(MP.monomials(p))
 end

--- a/src/scaled.jl
+++ b/src/scaled.jl
@@ -76,7 +76,7 @@ function change_basis(
 ) where {MT,MV}
     n = length(basis)
     scalings = map(scaling, basis.monomials)
-    scaled_Q = [Q[i, j] * scalings[i] * scalings[j] for i = 1:n, j = 1:n]
+    scaled_Q = [Q[i, j] * scalings[i] * scalings[j] for i in 1:n, j in 1:n]
     return scaled_Q, MonomialBasis(basis.monomials)
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariateBases = "be282fd4-ad43-11e9-1d11-8bd9d7e43378"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/chebyshev.jl
+++ b/test/chebyshev.jl
@@ -7,14 +7,18 @@ using MultivariateBases
         x -> [1, x, 2x^2 - 1, 4x^3 - 3x, 8x^4 - 8x^2 + 1],
         true,
     )
-    univ_orthogonal_test(ChebyshevBasis, i -> π * (1 / 2 + (0^i) / 2), atol = 1e-12)
+    univ_orthogonal_test(
+        ChebyshevBasis,
+        i -> π * (1 / 2 + (0^i) / 2);
+        atol = 1e-12,
+    )
     orthogonal_test(
         ChebyshevBasisSecondKind,
         x -> [1, 2x, 4x^2 - 1, 8x^3 - 4x, 16x^4 - 12x^2 + 1],
         true,
     )
 
-    univ_orthogonal_test(ChebyshevBasisSecondKind, i -> π / 2, atol = 1e-12)
+    univ_orthogonal_test(ChebyshevBasisSecondKind, i -> π / 2; atol = 1e-12)
 end
 
 @testset "API degree = $degree" for degree in 0:3
@@ -22,14 +26,31 @@ end
     api_test(ChebyshevBasisSecondKind, degree)
 end
 
-
 @testset "Coefficients" begin
     coefficient_test(
         ChebyshevBasis,
-        reverse([0.0625, 0.0625, 0.0625, -0.25, 0.0625, -0.3125, -0.3125, 0.625]),
+        reverse([
+            0.0625,
+            0.0625,
+            0.0625,
+            -0.25,
+            0.0625,
+            -0.3125,
+            -0.3125,
+            0.625,
+        ]),
     )
     coefficient_test(
         ChebyshevBasisSecondKind,
-        reverse([0.015625, 0.015625, 0.015625, -0.09375, 0.015625, -0.109375, -0.109375, 0.875]),
+        reverse([
+            0.015625,
+            0.015625,
+            0.015625,
+            -0.09375,
+            0.015625,
+            -0.109375,
+            -0.109375,
+            0.875,
+        ]),
     )
 end

--- a/test/chebyshev.jl
+++ b/test/chebyshev.jl
@@ -7,14 +7,29 @@ using MultivariateBases
         x -> [1, x, 2x^2 - 1, 4x^3 - 3x, 8x^4 - 8x^2 + 1],
         true,
     )
+    univ_orthogonal_test(ChebyshevBasis, i -> π * (1 / 2 + (0^i) / 2), atol = 1e-12)
     orthogonal_test(
         ChebyshevBasisSecondKind,
         x -> [1, 2x, 4x^2 - 1, 8x^3 - 4x, 16x^4 - 12x^2 + 1],
         true,
     )
+
+    univ_orthogonal_test(ChebyshevBasisSecondKind, i -> π / 2, atol = 1e-12)
 end
 
 @testset "API degree = $degree" for degree in 0:3
     api_test(ChebyshevBasis, degree)
     api_test(ChebyshevBasisSecondKind, degree)
+end
+
+
+@testset "Coefficients" begin
+    coefficient_test(
+        ChebyshevBasis,
+        reverse([0.0625, 0.0625, 0.0625, -0.25, 0.0625, -0.3125, -0.3125, 0.625]),
+    )
+    coefficient_test(
+        ChebyshevBasisSecondKind,
+        reverse([0.015625, 0.015625, 0.015625, -0.09375, 0.015625, -0.109375, -0.109375, 0.875]),
+    )
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -72,3 +72,11 @@ end
     p = @inferred polynomial(zeros(Int, 0, 0), basis, Int)
     @test iszero(p)
 end
+
+@testset "Enumerate" begin
+    monos = [1, x, y^2]
+    basis = FixedPolynomialBasis(monos)
+    for (i, e) in enumerate(basis)
+        @test e == monos[i]
+    end
+end

--- a/test/hermite.jl
+++ b/test/hermite.jl
@@ -15,7 +15,7 @@ using MultivariateBases
     )
     univ_orthogonal_test(
         PhysicistsHermiteBasis,
-        i -> √(π) * factorial(i) * 2^i,
+        i -> √(π) * factorial(i) * 2^i;
         atol = 1e-12,
     ) #precision issue
 end
@@ -28,11 +28,20 @@ end
 @testset "Coefficients" begin
     coefficient_test(
         ProbabilistsHermiteBasis,
-        [4, 6, 6, 1, 9, 1, 1, 1],
+        [4, 6, 6, 1, 9, 1, 1, 1];
         atol = 1e-12,
     )
     coefficient_test(
         PhysicistsHermiteBasis,
-        reverse([0.015625, 0.015625, 0.03125, 0.1875, 0.03125, 0.1875, 0.1875, 1.0]),
+        reverse([
+            0.015625,
+            0.015625,
+            0.03125,
+            0.1875,
+            0.03125,
+            0.1875,
+            0.1875,
+            1.0,
+        ]),
     )
 end

--- a/test/hermite.jl
+++ b/test/hermite.jl
@@ -7,14 +7,32 @@ using MultivariateBases
         x -> [1, x, x^2 - 1, x^3 - 3x, x^4 - 6x^2 + 3],
         true,
     )
+    univ_orthogonal_test(ProbabilistsHermiteBasis, i -> √(2 * π) * factorial(i))
     orthogonal_test(
         PhysicistsHermiteBasis,
         x -> [1, 2x, 4x^2 - 2, 8x^3 - 12x, 16x^4 - 48x^2 + 12],
         true,
     )
+    univ_orthogonal_test(
+        PhysicistsHermiteBasis,
+        i -> √(π) * factorial(i) * 2^i,
+        atol = 1e-12,
+    ) #precision issue
 end
 
 @testset "API degree = $degree" for degree in 0:3
     api_test(ProbabilistsHermiteBasis, degree)
     api_test(PhysicistsHermiteBasis, degree)
+end
+
+@testset "Coefficients" begin
+    coefficient_test(
+        ProbabilistsHermiteBasis,
+        [4, 6, 6, 1, 9, 1, 1, 1],
+        atol = 1e-12,
+    )
+    coefficient_test(
+        PhysicistsHermiteBasis,
+        reverse([0.015625, 0.015625, 0.03125, 0.1875, 0.03125, 0.1875, 0.1875, 1.0]),
+    )
 end

--- a/test/laguerre.jl
+++ b/test/laguerre.jl
@@ -13,8 +13,39 @@ using MultivariateBases
         ],
         false,
     )
+
+    univ_orthogonal_test(LaguerreBasis, i -> 1; atol = 1e-12) # there are precision issues
 end
 
 @testset "API degree = $degree" for degree in 0:3
     api_test(LaguerreBasis, degree)
+end
+
+@testset "Coefficients" begin
+    coefficient_test(
+        LaguerreBasis,
+        reverse([
+            48.0,
+            48.0,
+            -96.0,
+            -192.0,
+            -192.0,
+            -96.0,
+            48.0,
+            384.0,
+            564.0,
+            384.0,
+            48.0,
+            -192.0,
+            -744.0,
+            -744.0,
+            -192.0,
+            324.0,
+            720.0,
+            324.0,
+            -264.0,
+            -264.0,
+            85.0,
+        ]),
+    )
 end

--- a/test/legendre.jl
+++ b/test/legendre.jl
@@ -7,8 +7,26 @@ using MultivariateBases
         x -> [1, x, (3x^2 - 1) / 2, (5x^3 - 3x) / 2, (35x^4 - 30x^2 + 3) / 8],
         true,
     )
+
+    univ_orthogonal_test(LegendreBasis, i -> 2 / (2 * i + 1))
 end
 
 @testset "API degree = $degree" for degree in 0:3
     api_test(LegendreBasis, degree)
+end
+
+@testset "Coefficients" begin
+    coefficient_test(
+        LegendreBasis,
+        reverse([
+            0.1523809523809524,
+            0.1523809523809524,
+            0.0761904761904762,
+            -0.5714285714285714,
+            0.0761904761904762,
+            -0.3428571428571428,
+            -0.3428571428571428,
+            0.8,
+        ]),
+    )
 end

--- a/test/monomial.jl
+++ b/test/monomial.jl
@@ -66,3 +66,15 @@ end
     p = @inferred polynomial(zeros(Int, 0, 0), basis, Int)
     @test iszero(p)
 end
+
+@testset "Enumerate" begin
+    monos = [1, y, x]
+    basis = MonomialBasis(monos)
+    for (i, e) in enumerate(basis)
+        @test e == monos[i]
+    end
+end
+
+@testset "Coefficients" begin
+    coefficient_test(MonomialBasis, [1, -3, 1, 1])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using Test
 
 using MultivariateBases
-
+using LinearAlgebra
 using DynamicPolynomials
+
 
 function api_test(B::Type{<:AbstractPolynomialBasis}, degree)
     @polyvar x[1:2]
@@ -24,6 +25,17 @@ function api_test(B::Type{<:AbstractPolynomialBasis}, degree)
               polynomial_type(basis, Float64)
         @test polynomial(ones(n, n), basis, Float64) isa
               polynomial_type(basis, Float64)
+    end
+end
+
+function univ_orthogonal_test(B::Type{<:AbstractMultipleOrthogonalBasis}, univ::Function; kwargs...)
+    @polyvar x
+    basis = maxdegree_basis(B, [x], 4)
+    for i = eachindex(basis)
+        @test isapprox(dot(basis[i], basis[i], B), univ(maxdegree(basis[i])); kwargs...)
+        for j = 1:i-1
+            @test isapprox(dot(basis[i], basis[j], B), 0.0; kwargs...)
+        end
     end
 end
 
@@ -66,6 +78,15 @@ function orthogonal_test(
             @test monos.polynomials[i] == univariate_x[exps[i]+1]
         end
     end
+end
+
+function coefficient_test(B::Type{<:AbstractPolynomialBasis}, coefs; kwargs...)
+    @polyvar x y
+    p = x^4 * y^2 + x^2 * y^4 - 3 * x^2 * y^2 + 1
+    basis = basis_covering_monomials(B, monomials(p))
+    cc = coefficients(p, basis)
+    @test isapprox(coefs, cc; kwargs...)
+    @test isapprox(p, polynomial(cc, basis); kwargs...)
 end
 
 @testset "Monomial" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using MultivariateBases
 using LinearAlgebra
 using DynamicPolynomials
 
-
 function api_test(B::Type{<:AbstractPolynomialBasis}, degree)
     @polyvar x[1:2]
     for basis in [
@@ -28,12 +27,20 @@ function api_test(B::Type{<:AbstractPolynomialBasis}, degree)
     end
 end
 
-function univ_orthogonal_test(B::Type{<:AbstractMultipleOrthogonalBasis}, univ::Function; kwargs...)
+function univ_orthogonal_test(
+    B::Type{<:AbstractMultipleOrthogonalBasis},
+    univ::Function;
+    kwargs...,
+)
     @polyvar x
     basis = maxdegree_basis(B, [x], 4)
-    for i = eachindex(basis)
-        @test isapprox(dot(basis[i], basis[i], B), univ(maxdegree(basis[i])); kwargs...)
-        for j = 1:i-1
+    for i in eachindex(basis)
+        @test isapprox(
+            dot(basis[i], basis[i], B),
+            univ(maxdegree(basis[i]));
+            kwargs...,
+        )
+        for j in 1:i-1
             @test isapprox(dot(basis[i], basis[j], B), 0.0; kwargs...)
         end
     end

--- a/test/scaled.jl
+++ b/test/scaled.jl
@@ -29,3 +29,18 @@ end
 @testset "API degree = $degree" for degree in 0:3
     api_test(ScaledMonomialBasis, degree)
 end
+
+@testset "Enumerate" begin
+    monos = [1, y, x]
+    basis = ScaledMonomialBasis(monos)
+    for (i, e) in enumerate(basis)
+        @test e == monos[i]
+    end
+end
+
+@testset "Coefficients" begin
+    coefficient_test(
+        ScaledMonomialBasis,
+        [1, -√3/√2, 1/√15, 1/√15],
+    )
+end

--- a/test/scaled.jl
+++ b/test/scaled.jl
@@ -39,8 +39,5 @@ end
 end
 
 @testset "Coefficients" begin
-    coefficient_test(
-        ScaledMonomialBasis,
-        [1, -√3/√2, 1/√15, 1/√15],
-    )
+    coefficient_test(ScaledMonomialBasis, [1, -√3 / √2, 1 / √15, 1 / √15])
 end


### PR DESCRIPTION
I unified the interface for Monomial and Polynomial Bases (now the field is called elements).
The idea is, that `<:AbstractPolynomialBasis` is a wrapper for a familiy of polynomials that we label as a basis in some sense (similar to `MP.MonomialVector`).
I added `iterate`, `getindex`, and a `coefficients(poly, basis_type)` function which returns a vector of coefficients which should yield 
```julia
p == polynomial(coefficients(p, basis), basis_covering_monomials(basis, monomials(p))
```

I'm working on changes to depended packages.