### PR TITLE
Add indexing into each basis type

### DIFF
--- a/src/fixed.jl
+++ b/src/fixed.jl
@@ -8,6 +8,10 @@ function Base.copy(basis::AbstractPolynomialVectorBasis)
     return typeof(basis)(copy(basis.polynomials))
 end
 
+Base.firstindex(basis::AbstractPolynomialVectorBasis) = 1
+Base.lastindex(basis::AbstractPolynomialVectorBasis) = length(basis)
+Base.getindex(basis::AbstractPolynomialVectorBasis, i::Int) = basis.polynomials[i]
+
 function MP.nvariables(basis::AbstractPolynomialVectorBasis)
     return MP.nvariables(basis.polynomials)
 end

--- a/src/monomial.jl
+++ b/src/monomial.jl
@@ -5,6 +5,8 @@ abstract type AbstractMonomialBasis{
 
 Base.length(basis::AbstractMonomialBasis) = length(basis.monomials)
 Base.copy(basis::AbstractMonomialBasis) = typeof(basis)(copy(basis.monomials))
+Base.firstindex(basis::AbstractMonomialBasis) = 1
+Base.lastindex(basis::AbstractMonomialBasis) = length(basis)
 
 MP.nvariables(basis::AbstractMonomialBasis) = MP.nvariables(basis.monomials)
 MP.variables(basis::AbstractMonomialBasis) = MP.variables(basis.monomials)
@@ -70,6 +72,8 @@ end
 function MonomialBasis(monomials::AbstractVector)
     return MonomialBasis(MP.monomial_vector(monomials))
 end
+
+Base.getindex(basis::MonomialBasis, i::Int) = basis.monomials[i]
 
 function MP.polynomial_type(
     ::Union{MonomialBasis{MT},Type{<:MonomialBasis{MT}}},

--- a/src/scaled.jl
+++ b/src/scaled.jl
@@ -41,6 +41,11 @@ function ScaledMonomialBasis(monomials)
     return ScaledMonomialBasis(MP.monomial_vector(monomials))
 end
 
+function Base.getindex(basis::ScaledMonomialBasis, i::Int)
+    mono = basis.monomials[i]
+    return scaling(mono) * mono
+end
+
 function MP.polynomial_type(::ScaledMonomialBasis{MT}, T::Type) where {MT}
     return MP.polynomial_type(MT, promote_type(T, Float64))
 end

--- a/test/fixed.jl
+++ b/test/fixed.jl
@@ -7,6 +7,8 @@ using DynamicPolynomials
     basis = FixedPolynomialBasis([1 - x^2, x^2 + 2])
     @test polynomial_type(basis, Int) == polynomial_type(x, Int)
     @test polynomial(one, basis) == 3
+    @test basis[1] == 1 - x^2
+    @test basis[2] == x^2 + 2
 end
 @testset "Monomial" begin
     basis = FixedPolynomialBasis([x, x^2])

--- a/test/monomial.jl
+++ b/test/monomial.jl
@@ -8,6 +8,8 @@ using DynamicPolynomials
     @test polynomial_type(basis, Int) == polynomial_type(x, Int)
     @test polynomial(i -> i^2, basis) == 4x + y
     @test coefficients(x + 4y, MonomialBasis) == [4, 1]
+    @test basis[1] == y
+    @test basis[2] == x
 end
 @testset "Affine" begin
     # It will be sorted and 1 will be moved at the end

--- a/test/scaled.jl
+++ b/test/scaled.jl
@@ -22,6 +22,9 @@ end
     @test polynomial(i -> i^2, basis) == x^2 + 4 * √2 * x * y + 9y^2
     @test coefficients(x^2 + 4x * y + 9y^2, ScaledMonomialBasis) ==
           [9, 4 / √2, 1]
+    @test basis[1] == x^2
+    @test basis[2] == √2 * x * y 
+    @test basis[3] == y^2
 end
 @testset "API degree = $degree" for degree in 0:3
     api_test(ScaledMonomialBasis, degree)


### PR DESCRIPTION
Add [indexing](https://docs.julialang.org/en/v1/manual/interfaces/#Indexing) interface to each basis type using `Base.getindex`. This is to enable improvements downstream in SumOfSquares.jl (sparse DSOS specificially). 