### PR TITLE
Swap argument of promote_basis

### DIFF
--- a/src/mstructures.jl
+++ b/src/mstructures.jl
@@ -33,9 +33,9 @@ end
 
 SA.promote_with_map(::MStruct, b, m) = MStruct(b), m
 
-function SA.promote_basis_with_maps(a::SA.AbstractBasis, b::MStruct)
-    _a, _b = SA.promote_basis_with_maps(a, SA.basis(b))
-    return _a, SA.maybe_promote(b, _b...)
+function SA.promote_basis_with_maps(a::MStruct, b::SA.AbstractBasis)
+    _b, _a = SA.promote_basis_with_maps(b, SA.basis(a))
+    return SA.maybe_promote(a, _a...), _b
 end
 
 function SA.promote_object(v::Variables, m::MStruct, map)

--- a/test/monomial.jl
+++ b/test/monomial.jl
@@ -105,3 +105,16 @@ end
 @testset "Coefficients" begin
     coefficient_test(MB.Monomial, [1, -3, 1, 1])
 end
+
+@testset "promote_basis_with_maps" begin
+    @polyvar x[1:2]
+    mono = x[1]^2
+    a = MB.algebra_element(x[1] - x[1]^2)
+    b = MB.FullBasis{MB.Monomial}(x[1] * x[2])
+    a2, b2 = SA.promote_basis(a, b)
+    @test a2.coeffs.basis_elements == [[1, 0], [2, 0]]
+    @test a2.coeffs.basis_elements == [[1, 0], [2, 0]]
+    @test SA.basis(a) != b
+    @test SA.basis(a2) == b
+    b2 === b
+end


### PR DESCRIPTION
The convention chosen in StarAlgebras is that we should implement method with the inner type in second argument